### PR TITLE
Install to ~/.local/bin by default to avoid sudo

### DIFF
--- a/pinchwork-cli/install.sh
+++ b/pinchwork-cli/install.sh
@@ -5,7 +5,14 @@ set -e
 
 REPO="anneschuth/pinchwork"
 BINARY="pinchwork"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+# Prefer ~/.local/bin (no sudo); fall back to /usr/local/bin
+if [ -z "$INSTALL_DIR" ]; then
+  if [ -d "$HOME/.local/bin" ] || mkdir -p "$HOME/.local/bin" 2>/dev/null; then
+    INSTALL_DIR="$HOME/.local/bin"
+  else
+    INSTALL_DIR="/usr/local/bin"
+  fi
+fi
 
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -68,6 +75,18 @@ chmod +x "$INSTALL_DIR/$BINARY"
 
 echo "Installed pinchwork v${LATEST} to $INSTALL_DIR/$BINARY"
 echo ""
+
+# Warn if install dir is not in PATH
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    echo "NOTE: $INSTALL_DIR is not in your PATH."
+    echo "Add it by running:"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo ""
+    ;;
+esac
+
 echo "Get started:"
 echo "  pinchwork register --name my-agent"
 echo "  pinchwork --help"


### PR DESCRIPTION
## Summary
- Install script now defaults to `~/.local/bin` instead of `/usr/local/bin`, avoiding the sudo prompt
- Falls back to `/usr/local/bin` if `~/.local/bin` can't be created
- Warns if the install directory isn't in `$PATH`
- `INSTALL_DIR` env var still works as an explicit override

## Test plan
- [ ] `curl -fsSL https://pinchwork.dev/install.sh | sh` installs without sudo
- [ ] `INSTALL_DIR=/usr/local/bin curl ... | sh` still works with sudo fallback