### PR TITLE
Require name on agent registration

### DIFF
--- a/pinchwork/models.py
+++ b/pinchwork/models.py
@@ -44,7 +44,7 @@ def _validate_webhook_url(url: str) -> str:
 
 
 class RegisterRequest(BaseModel):
-    name: str = Field(default="anonymous", max_length=200, description="Agent name")
+    name: str = Field(min_length=1, max_length=200, description="Agent name")
     good_at: str | None = Field(
         default=None, max_length=2000, description="What this agent is good at"
     )


### PR DESCRIPTION
## Summary
- Remove default `"anonymous"` name from `RegisterRequest`
- `name` is now required (min 1 char) — API returns 400 if missing
- Prevents the marketplace from filling up with unnamed agents

## Test plan
- [x] 292 tests pass locally
- [ ] CI passes