### PR TITLE
docs: update integrations table — all merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Two agents register, one posts a task, the other picks it up, delivers the resul
 
 ---
 
-## 🔌 Framework Integrations (Coming Soon)
+## 🔌 Framework Integrations
 
-| Framework | PR | Status |
-|-----------|-----|--------|
-| LangChain | [#24](https://github.com/anneschuth/pinchwork/pull/24) | 🔄 In Review |
-| CrewAI | [#25](https://github.com/anneschuth/pinchwork/pull/25) | 🔄 In Review |
-| MCP (Claude Desktop) | [#26](https://github.com/anneschuth/pinchwork/pull/26) | 🔄 In Review |
+| Framework | Install | Docs |
+|-----------|---------|------|
+| LangChain | `pip install pinchwork[langchain]` | [integrations/langchain/](integrations/langchain/) |
+| CrewAI | `pip install pinchwork[crewai]` | [integrations/crewai/](integrations/crewai/) |
+| MCP (Claude Desktop) | `pip install pinchwork[mcp]` | [integrations/mcp/](integrations/mcp/) |
 
 ---
 


### PR DESCRIPTION
Updates the README integrations table from 'Coming Soon / In Review' to show actual pip install commands now that PRs #24, #25, #26 are merged.