### PR TITLE
feat: A2A JSON-RPC 2.0 endpoint

### DIFF
--- a/pinchwork/api/a2a.py
+++ b/pinchwork/api/a2a.py
@@ -1,15 +1,37 @@
-"""A2A Protocol Agent Card endpoint.
+"""A2A Protocol endpoints: Agent Card + JSON-RPC 2.0.
 
 Serves the Pinchwork Agent Card at /.well-known/agent-card.json
-following the A2A Protocol specification (https://a2a-protocol.org).
+and implements a JSON-RPC 2.0 endpoint at /a2a for the A2A protocol.
 
-This makes Pinchwork discoverable by any A2A-compatible agent or registry.
+Supported methods:
+- message/send  → Create a task from an A2A message
+- tasks/get     → Retrieve task status by ID
+- tasks/cancel  → Cancel a posted task
+
+See https://a2a-protocol.org for the full specification.
 """
 
-from fastapi import APIRouter
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
+from pinchwork.auth import get_current_agent
+from pinchwork.database import get_db_session
+from pinchwork.db_models import Agent
+from pinchwork.services.tasks import cancel_task, create_task, get_task
+
+logger = logging.getLogger("pinchwork.a2a")
+
 router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# A2A Agent Card
+# ---------------------------------------------------------------------------
 
 AGENT_CARD = {
     "name": "Pinchwork",
@@ -130,3 +152,314 @@ async def agent_card() -> JSONResponse:
             "Cache-Control": "public, max-age=3600",
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC 2.0 helpers
+# ---------------------------------------------------------------------------
+
+JSONRPC_VERSION = "2.0"
+
+# A2A error codes (application-level, in the -32000 range)
+TASK_NOT_FOUND = -32001
+INVALID_PARAMS = -32602
+METHOD_NOT_FOUND = -32601
+INTERNAL_ERROR = -32603
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+UNSUPPORTED_OPERATION = -32004
+
+
+def _jsonrpc_error(
+    code: int,
+    message: str,
+    req_id: str | int | None = None,
+    data: Any = None,
+) -> JSONResponse:
+    """Build a JSON-RPC 2.0 error response."""
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return JSONResponse(
+        content={"jsonrpc": JSONRPC_VERSION, "id": req_id, "error": error},
+        status_code=200,  # JSON-RPC always returns 200
+    )
+
+
+def _jsonrpc_result(result: Any, req_id: str | int | None) -> JSONResponse:
+    """Build a JSON-RPC 2.0 success response."""
+    return JSONResponse(
+        content={"jsonrpc": JSONRPC_VERSION, "id": req_id, "result": result},
+        status_code=200,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A2A data model helpers
+# ---------------------------------------------------------------------------
+
+
+def _task_to_a2a(task: dict) -> dict:
+    """Convert a Pinchwork task dict to an A2A Task object."""
+    # Map Pinchwork statuses to A2A task states
+    status_map = {
+        "posted": "submitted",
+        "claimed": "working",
+        "delivered": "completed",
+        "approved": "completed",
+        "expired": "canceled",
+        "cancelled": "canceled",
+    }
+    a2a_status = status_map.get(task.get("status", ""), "unknown")
+
+    a2a_task: dict[str, Any] = {
+        "id": task["id"],
+        "status": {
+            "state": a2a_status,
+        },
+    }
+
+    # Add message if present (task need as the original user message)
+    if task.get("need"):
+        a2a_task["status"]["message"] = {
+            "role": "agent",
+            "parts": [{"kind": "text", "text": f"Task accepted: {task['need']}"}],
+        }
+
+    # Add artifacts if the task has a result
+    if task.get("result"):
+        a2a_task["artifacts"] = [
+            {
+                "artifactId": str(uuid.uuid5(uuid.NAMESPACE_URL, task["id"])),
+                "parts": [{"kind": "text", "text": task["result"]}],
+            }
+        ]
+
+    # Include metadata
+    metadata: dict[str, Any] = {}
+    if task.get("poster_id"):
+        metadata["poster_id"] = task["poster_id"]
+    if task.get("worker_id"):
+        metadata["worker_id"] = task["worker_id"]
+    if task.get("max_credits"):
+        metadata["max_credits"] = task["max_credits"]
+    if task.get("credits_charged") is not None:
+        metadata["credits_charged"] = task["credits_charged"]
+    if task.get("tags"):
+        metadata["tags"] = task["tags"]
+    if metadata:
+        a2a_task["metadata"] = metadata
+
+    return a2a_task
+
+
+def _extract_text_from_parts(parts: list[dict]) -> str:
+    """Extract text content from A2A message parts."""
+    texts = []
+    for part in parts:
+        kind = part.get("kind", part.get("type", ""))
+        if kind == "text" or "text" in part:
+            texts.append(part.get("text", ""))
+    return "\n".join(texts).strip()
+
+
+# ---------------------------------------------------------------------------
+# A2A method handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_message_send(
+    params: dict,
+    agent: Agent,
+    session: Any,
+) -> dict:
+    """Handle message/send: create a task from an A2A message.
+
+    Expected params:
+    {
+        "message": {
+            "role": "user",
+            "parts": [{"kind": "text", "text": "..."}]
+        },
+        "configuration": {  // optional
+            "acceptedOutputModes": [...],
+        },
+        "metadata": {  // optional - Pinchwork-specific
+            "max_credits": 50,
+            "tags": ["code-review"],
+            "context": "additional context"
+        }
+    }
+    """
+    message = params.get("message")
+    if not message or not isinstance(message, dict):
+        raise ValueError("Missing or invalid 'message' in params")
+
+    parts = message.get("parts", [])
+    if not parts:
+        raise ValueError("Message must contain at least one part")
+
+    # Extract the task description from message parts
+    need = _extract_text_from_parts(parts)
+    if not need:
+        raise ValueError("Message must contain text content")
+
+    # Extract optional Pinchwork-specific metadata
+    metadata = params.get("metadata", {})
+    max_credits = metadata.get("max_credits", 50)
+    tags = metadata.get("tags")
+    context = metadata.get("context")
+
+    # Validate max_credits
+    if not isinstance(max_credits, int) or max_credits < 1:
+        max_credits = 50
+
+    # Create the task via existing service
+    task = await create_task(
+        session,
+        agent.id,
+        need,
+        max_credits,
+        tags=tags,
+        context=context,
+    )
+
+    # Enrich with poster_id (create_task doesn't include it)
+    task["poster_id"] = agent.id
+
+    # Return the task in A2A format
+    return _task_to_a2a(task)
+
+
+async def _handle_tasks_get(
+    params: dict,
+    agent: Agent,
+    session: Any,
+) -> dict:
+    """Handle tasks/get: retrieve a task by ID.
+
+    Expected params:
+    {
+        "id": "task-id-here",
+        "historyLength": 10  // optional, ignored for now
+    }
+    """
+    task_id = params.get("id")
+    if not task_id:
+        raise ValueError("Missing 'id' in params")
+
+    task = await get_task(session, task_id)
+    if not task:
+        raise LookupError(f"Task not found: {task_id}")
+
+    # Access control: only poster or worker
+    if task["poster_id"] != agent.id and task.get("worker_id") != agent.id:
+        raise LookupError(f"Task not found: {task_id}")
+
+    return _task_to_a2a(task)
+
+
+async def _handle_tasks_cancel(
+    params: dict,
+    agent: Agent,
+    session: Any,
+) -> dict:
+    """Handle tasks/cancel: cancel a posted task.
+
+    Expected params:
+    {
+        "id": "task-id-here"
+    }
+    """
+    task_id = params.get("id")
+    if not task_id:
+        raise ValueError("Missing 'id' in params")
+
+    task = await cancel_task(session, task_id, agent.id)
+    return _task_to_a2a(task)
+
+
+# Method dispatch table
+A2A_METHODS = {
+    "message/send": _handle_message_send,
+    "tasks/get": _handle_tasks_get,
+    "tasks/cancel": _handle_tasks_cancel,
+}
+
+
+# ---------------------------------------------------------------------------
+# Main JSON-RPC endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/a2a")
+async def a2a_jsonrpc(
+    request: Request,
+    agent: Agent = Depends(get_current_agent),
+    session=Depends(get_db_session),
+) -> JSONResponse:
+    """A2A Protocol JSON-RPC 2.0 endpoint.
+
+    Accepts JSON-RPC 2.0 requests and dispatches to the appropriate handler.
+    Requires Bearer token authentication (same as the REST API).
+    """
+    # Parse request body
+    try:
+        body = await request.json()
+    except Exception:
+        return _jsonrpc_error(PARSE_ERROR, "Parse error: invalid JSON")
+
+    # Validate JSON-RPC envelope
+    if not isinstance(body, dict):
+        return _jsonrpc_error(INVALID_REQUEST, "Invalid request: expected JSON object")
+
+    jsonrpc = body.get("jsonrpc")
+    if jsonrpc != JSONRPC_VERSION:
+        return _jsonrpc_error(
+            INVALID_REQUEST,
+            f"Invalid JSON-RPC version: expected '{JSONRPC_VERSION}'",
+            req_id=body.get("id"),
+        )
+
+    method = body.get("method")
+    req_id = body.get("id")
+    params = body.get("params", {})
+
+    if not method or not isinstance(method, str):
+        return _jsonrpc_error(INVALID_REQUEST, "Missing or invalid 'method'", req_id=req_id)
+
+    if not isinstance(params, dict):
+        return _jsonrpc_error(INVALID_PARAMS, "Params must be an object", req_id=req_id)
+
+    # Dispatch to handler
+    handler = A2A_METHODS.get(method)
+    if not handler:
+        return _jsonrpc_error(
+            METHOD_NOT_FOUND,
+            f"Method not found: {method}",
+            req_id=req_id,
+        )
+
+    try:
+        result = await handler(params, agent, session)
+        return _jsonrpc_result(result, req_id)
+    except ValueError as e:
+        return _jsonrpc_error(INVALID_PARAMS, str(e), req_id=req_id)
+    except LookupError as e:
+        return _jsonrpc_error(TASK_NOT_FOUND, str(e), req_id=req_id)
+    except Exception as e:
+        logger.exception("A2A handler error for method %s", method)
+        # Map HTTPException to appropriate JSON-RPC errors
+        from fastapi import HTTPException
+
+        if isinstance(e, HTTPException):
+            if e.status_code == 404:
+                return _jsonrpc_error(TASK_NOT_FOUND, e.detail, req_id=req_id)
+            if e.status_code == 403:
+                return _jsonrpc_error(TASK_NOT_FOUND, "Task not found", req_id=req_id)
+            if e.status_code == 409:
+                return _jsonrpc_error(
+                    UNSUPPORTED_OPERATION, e.detail, req_id=req_id
+                )
+            return _jsonrpc_error(INTERNAL_ERROR, e.detail, req_id=req_id)
+        return _jsonrpc_error(INTERNAL_ERROR, "Internal error", req_id=req_id)

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,0 +1,495 @@
+"""Tests for the A2A JSON-RPC 2.0 endpoint."""
+
+import pytest
+
+from tests.conftest import auth_header, register_agent
+
+
+# ---------------------------------------------------------------------------
+# Agent Card
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_card(client):
+    resp = await client.get("/.well-known/agent-card.json")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Pinchwork"
+    assert data["capabilities"]["streaming"] is False
+    assert data["capabilities"]["pushNotifications"] is False
+    assert len(data["skills"]) >= 4
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC envelope validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2a_requires_auth(client):
+    """A2A endpoint requires Bearer auth just like the REST API."""
+    resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "message/send",
+            "params": {},
+        },
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_a2a_invalid_json(registered_agent):
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        content=b"not json",
+        headers={**auth_header(api_key), "Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"]["code"] == -32700  # Parse error
+
+
+@pytest.mark.asyncio
+async def test_a2a_invalid_jsonrpc_version(registered_agent):
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={"jsonrpc": "1.0", "id": "1", "method": "message/send", "params": {}},
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    assert data["error"]["code"] == -32600  # Invalid request
+
+
+@pytest.mark.asyncio
+async def test_a2a_method_not_found(registered_agent):
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={"jsonrpc": "2.0", "id": "1", "method": "nonexistent/method", "params": {}},
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    assert data["error"]["code"] == -32601  # Method not found
+    assert data["id"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_a2a_missing_method(registered_agent):
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={"jsonrpc": "2.0", "id": "1", "params": {}},
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    assert data["error"]["code"] == -32600  # Invalid request
+
+
+# ---------------------------------------------------------------------------
+# message/send
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_send(registered_agent):
+    """message/send creates a Pinchwork task and returns an A2A Task."""
+    client, agent_id, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "msg-1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "Review my Python code for bugs"}],
+                },
+            },
+        },
+        headers=auth_header(api_key),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["jsonrpc"] == "2.0"
+    assert data["id"] == "msg-1"
+    assert "result" in data
+    assert "error" not in data
+
+    task = data["result"]
+    assert "id" in task
+    assert task["status"]["state"] == "submitted"
+    assert task["metadata"]["poster_id"] == agent_id
+
+
+@pytest.mark.asyncio
+async def test_message_send_with_metadata(registered_agent):
+    """message/send accepts Pinchwork-specific metadata (credits, tags)."""
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "msg-2",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "Write a blog post about AI agents"}],
+                },
+                "metadata": {
+                    "max_credits": 25,
+                    "tags": ["writing", "blog"],
+                    "context": "Target audience: developers",
+                },
+            },
+        },
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    task = data["result"]
+    assert task["status"]["state"] == "submitted"
+    assert task["metadata"]["max_credits"] == 25
+
+
+@pytest.mark.asyncio
+async def test_message_send_empty_parts(registered_agent):
+    """message/send rejects messages with no parts."""
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "msg-3",
+            "method": "message/send",
+            "params": {
+                "message": {"role": "user", "parts": []},
+            },
+        },
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    assert data["error"]["code"] == -32602  # Invalid params
+
+
+@pytest.mark.asyncio
+async def test_message_send_missing_message(registered_agent):
+    """message/send rejects requests without a message."""
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "msg-4",
+            "method": "message/send",
+            "params": {},
+        },
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    assert data["error"]["code"] == -32602
+
+
+# ---------------------------------------------------------------------------
+# tasks/get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tasks_get(registered_agent):
+    """tasks/get retrieves a task in A2A format."""
+    client, agent_id, api_key = registered_agent
+
+    # First create a task via message/send
+    create_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "c1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "Do some research"}],
+                },
+            },
+        },
+        headers=auth_header(api_key),
+    )
+    task_id = create_resp.json()["result"]["id"]
+
+    # Now get it
+    get_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "g1",
+            "method": "tasks/get",
+            "params": {"id": task_id},
+        },
+        headers=auth_header(api_key),
+    )
+    data = get_resp.json()
+    assert data["id"] == "g1"
+    assert data["result"]["id"] == task_id
+    assert data["result"]["status"]["state"] == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_tasks_get_not_found(registered_agent):
+    """tasks/get returns error for non-existent task."""
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "g2",
+            "method": "tasks/get",
+            "params": {"id": "nonexistent-task-id"},
+        },
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    assert data["error"]["code"] == -32001  # Task not found
+
+
+@pytest.mark.asyncio
+async def test_tasks_get_access_control(two_agents):
+    """tasks/get denies access to tasks not owned by the caller."""
+    client = two_agents["client"]
+    poster = two_agents["poster"]
+    worker = two_agents["worker"]
+
+    # Poster creates a task
+    create_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "c1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "Secret task"}],
+                },
+            },
+        },
+        headers=auth_header(poster["key"]),
+    )
+    task_id = create_resp.json()["result"]["id"]
+
+    # Worker tries to get it (should fail — not poster or worker)
+    get_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "g1",
+            "method": "tasks/get",
+            "params": {"id": task_id},
+        },
+        headers=auth_header(worker["key"]),
+    )
+    data = get_resp.json()
+    assert data["error"]["code"] == -32001
+
+
+@pytest.mark.asyncio
+async def test_tasks_get_missing_id(registered_agent):
+    """tasks/get rejects requests without an id."""
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "g3",
+            "method": "tasks/get",
+            "params": {},
+        },
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    assert data["error"]["code"] == -32602
+
+
+# ---------------------------------------------------------------------------
+# tasks/cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tasks_cancel(registered_agent):
+    """tasks/cancel cancels a posted task."""
+    client, agent_id, api_key = registered_agent
+
+    # Create a task
+    create_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "c1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "Task to cancel"}],
+                },
+            },
+        },
+        headers=auth_header(api_key),
+    )
+    task_id = create_resp.json()["result"]["id"]
+
+    # Cancel it
+    cancel_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "x1",
+            "method": "tasks/cancel",
+            "params": {"id": task_id},
+        },
+        headers=auth_header(api_key),
+    )
+    data = cancel_resp.json()
+    assert data["id"] == "x1"
+    assert data["result"]["status"]["state"] == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_tasks_cancel_not_poster(two_agents):
+    """tasks/cancel denies cancellation by non-poster."""
+    client = two_agents["client"]
+    poster = two_agents["poster"]
+    worker = two_agents["worker"]
+
+    # Poster creates a task
+    create_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "c1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "Not your task"}],
+                },
+            },
+        },
+        headers=auth_header(poster["key"]),
+    )
+    task_id = create_resp.json()["result"]["id"]
+
+    # Worker tries to cancel (should fail)
+    cancel_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "x1",
+            "method": "tasks/cancel",
+            "params": {"id": task_id},
+        },
+        headers=auth_header(worker["key"]),
+    )
+    data = cancel_resp.json()
+    assert "error" in data
+
+
+@pytest.mark.asyncio
+async def test_tasks_cancel_missing_id(registered_agent):
+    """tasks/cancel rejects requests without an id."""
+    client, _, api_key = registered_agent
+    resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "x2",
+            "method": "tasks/cancel",
+            "params": {},
+        },
+        headers=auth_header(api_key),
+    )
+    data = resp.json()
+    assert data["error"]["code"] == -32602
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: message/send → tasks/get roundtrip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_send_then_get(registered_agent):
+    """Full roundtrip: create via message/send, retrieve via tasks/get."""
+    client, _, api_key = registered_agent
+
+    # Send
+    send_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "rt-1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "Roundtrip test task"}],
+                },
+                "metadata": {"max_credits": 10, "tags": ["test"]},
+            },
+        },
+        headers=auth_header(api_key),
+    )
+    task = send_resp.json()["result"]
+    assert task["status"]["state"] == "submitted"
+
+    # Get
+    get_resp = await client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "rt-2",
+            "method": "tasks/get",
+            "params": {"id": task["id"]},
+        },
+        headers=auth_header(api_key),
+    )
+    fetched = get_resp.json()["result"]
+    assert fetched["id"] == task["id"]
+    assert fetched["status"]["state"] == "submitted"
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC id propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_id_propagation(registered_agent):
+    """JSON-RPC id is always echoed back in responses."""
+    client, _, api_key = registered_agent
+
+    for req_id in ["string-id", 42, None]:
+        resp = await client.post(
+            "/a2a",
+            json={
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": f"id test {req_id}"}],
+                    },
+                },
+            },
+            headers=auth_header(api_key),
+        )
+        data = resp.json()
+        assert data["id"] == req_id


### PR DESCRIPTION
## Summary

Adds a full A2A protocol JSON-RPC 2.0 endpoint at `POST /a2a`, making Pinchwork the first live A2A-compatible agent marketplace.

## A2A Methods Implemented

| Method | Description | Maps to |
|--------|-------------|---------|
| `message/send` | Create a task from an A2A message | `create_task()` |
| `tasks/get` | Retrieve task status by ID | `get_task()` |
| `tasks/cancel` | Cancel a posted task | `cancel_task()` |

## How it works

The endpoint accepts standard JSON-RPC 2.0 requests with Bearer auth (same tokens as the REST API). It maps A2A concepts to Pinchwork's existing task lifecycle:

- **A2A Message parts** → Pinchwork task `need` field
- **A2A Task states** → `submitted` (posted), `working` (claimed), `completed` (delivered/approved), `canceled` (cancelled/expired)
- **A2A Artifacts** → Task results wrapped as A2A artifact parts
- **Pinchwork metadata** (credits, tags) available via the `metadata` param

### Example request
```json
{
  "jsonrpc": "2.0",
  "id": "1",
  "method": "message/send",
  "params": {
    "message": {
      "role": "user",
      "parts": [{"kind": "text", "text": "Review my Python code for bugs"}]
    },
    "metadata": {
      "max_credits": 25,
      "tags": ["code-review"]
    }
  }
}
```

## What's NOT included (intentionally)

- No streaming (`message/stream`) — Pinchwork supports long-polling via `wait` on the REST API instead
- No push notifications — not needed for the marketplace model
- No `tasks/list` — use the REST API's `GET /v1/tasks/available` for browsing

## Tests

19 new tests covering:
- JSON-RPC envelope validation (version, method, parse errors)
- All three methods with success and error cases
- Access control (task visibility, cancel permissions)
- End-to-end roundtrips (send → get)
- Request ID propagation

All existing tests continue to pass (43 total).

Closes #34