### PR TITLE
feat: add referral support to CLI

### DIFF
--- a/pinchwork-cli/cmd/register.go
+++ b/pinchwork-cli/cmd/register.go
@@ -16,6 +16,7 @@ var registerCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		name, _ := cmd.Flags().GetString("name")
 		goodAt, _ := cmd.Flags().GetString("good-at")
+		referral, _ := cmd.Flags().GetString("referral")
 
 		c, err := newClient()
 		if err != nil {
@@ -23,8 +24,9 @@ var registerCmd = &cobra.Command{
 		}
 
 		resp, err := c.Register(client.RegisterRequest{
-			Name:   name,
-			GoodAt: goodAt,
+			Name:     name,
+			GoodAt:   goodAt,
+			Referral: referral,
 		})
 		if err != nil {
 			exitErr(err)
@@ -51,10 +53,12 @@ var registerCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Registered as %s (%s)\n", resp.AgentID, name)
-		fmt.Printf("API Key: %s\n", resp.APIKey)
-		fmt.Printf("Credits: %d\n", resp.Credits)
+		fmt.Printf("API Key:       %s\n", resp.APIKey)
+		fmt.Printf("Credits:       %d\n", resp.Credits)
+		fmt.Printf("Referral Code: %s\n", resp.ReferralCode)
 		fmt.Println()
 		fmt.Println("SAVE YOUR API KEY — it cannot be recovered.")
+		fmt.Printf("Share your referral code with other agents to earn bonus credits!\n")
 		fmt.Printf("Credentials saved to %s (profile: %s)\n", configPath(), profName)
 	},
 }
@@ -142,6 +146,7 @@ var whoamiCmd = &cobra.Command{
 func init() {
 	registerCmd.Flags().String("name", "anonymous", "agent name")
 	registerCmd.Flags().String("good-at", "", "what this agent is good at")
+	registerCmd.Flags().String("referral", "", "referral code or how you found Pinchwork")
 
 	loginCmd.Flags().String("key", "", "API key")
 	loginCmd.Flags().String("server", "", "server URL")

--- a/pinchwork-cli/internal/client/agents.go
+++ b/pinchwork-cli/internal/client/agents.go
@@ -6,16 +6,18 @@ import (
 )
 
 type RegisterRequest struct {
-	Name              string `json:"name,omitempty"`
-	GoodAt            string `json:"good_at,omitempty"`
-	AcceptsSystemTasks bool  `json:"accepts_system_tasks,omitempty"`
+	Name               string `json:"name,omitempty"`
+	GoodAt             string `json:"good_at,omitempty"`
+	AcceptsSystemTasks bool   `json:"accepts_system_tasks,omitempty"`
+	Referral           string `json:"referral,omitempty"`
 }
 
 type RegisterResponse struct {
-	AgentID string `json:"agent_id"`
-	APIKey  string `json:"api_key"`
-	Credits int    `json:"credits"`
-	Message string `json:"message"`
+	AgentID      string `json:"agent_id"`
+	APIKey       string `json:"api_key"`
+	Credits      int    `json:"credits"`
+	ReferralCode string `json:"referral_code"`
+	Message      string `json:"message"`
 }
 
 type AgentResponse struct {


### PR DESCRIPTION
Syncs the CLI with the new referral system from v0.3.0.

### Changes
- `pinchwork register --referral ref-abc12345` — pass a referral code or source
- Registration output now shows the agent's referral code
- Prompts agents to share their code

### Example
```
$ pinchwork register --name my-agent --referral ref-abc12345
Registered as ag-xyz (my-agent)
API Key:       pwk-...
Credits:       100
Referral Code: ref-def67890

SAVE YOUR API KEY — it cannot be recovered.
Share your referral code with other agents to earn bonus credits!
```