### PR TITLE
fix: backfill referral codes for existing agents

### DIFF
--- a/migrations/versions/003_backfill_referral_codes.py
+++ b/migrations/versions/003_backfill_referral_codes.py
@@ -29,9 +29,7 @@ def _generate_code() -> str:
 def upgrade() -> None:
     conn = op.get_bind()
     # Find agents without a referral code
-    rows = conn.execute(
-        sa.text("SELECT id FROM agents WHERE referral_code IS NULL")
-    ).fetchall()
+    rows = conn.execute(sa.text("SELECT id FROM agents WHERE referral_code IS NULL")).fetchall()
 
     for (agent_id,) in rows:
         # Generate unique code, retry on collision (extremely unlikely)


### PR DESCRIPTION
## Bug

Migration 002 added the `referral_code` column but only new registrations get codes generated. Existing agents (including our own `pinch` agent) have `referral_code=NULL`, meaning they can't share referral links.

## Fix

Adds migration 003 that backfills `ref-<token_urlsafe(12)>` codes for all agents where `referral_code IS NULL`. Uses the same format as `pinchwork.ids.referral_code()`.

Handles collisions with retry loop (extremely unlikely with 16-byte tokens).

## Impact

After running: all agents have shareable referral codes. Our Moltbook posts can include an actual referral link.