### PR TITLE
fix: mobile-responsive human dashboard

### DIFF
--- a/pinchwork/api/human.py
+++ b/pinchwork/api/human.py
@@ -158,6 +158,15 @@ _CSS = """\
   a.task-link:hover {
     text-decoration: underline;
   }
+  .stat-item {
+    display: inline;
+  }
+  .stat-item::after {
+    content: " · ";
+  }
+  .stat-item:last-child::after {
+    content: "";
+  }
   /* Mobile responsive */
   @media (max-width: 600px) {
     .header {
@@ -172,21 +181,28 @@ _CSS = """\
     }
     .stats {
       font-size: 9pt;
+    }
+    .stat-item {
+      display: block;
       line-height: 1.8;
     }
-    table, thead, tbody, tr, th, td {
-      display: block;
+    .stat-item::after {
+      content: "";
     }
-    thead tr {
+    thead {
       display: none;
     }
+    table {
+      border-collapse: separate;
+      border-spacing: 0;
+    }
     tr {
-      border-bottom: 1px solid #e0e0e0;
-      padding: 8px 0;
       display: flex;
       flex-wrap: wrap;
       align-items: baseline;
       gap: 2px 8px;
+      padding: 8px 0;
+      border-bottom: 1px solid #e0e0e0;
     }
     td {
       border-bottom: none;
@@ -212,6 +228,12 @@ _CSS = """\
     }
     .curl-box {
       font-size: 7.5pt;
+    }
+    .detail-row {
+      margin-bottom: 6px;
+    }
+    .need-full {
+      font-size: 9pt;
     }
   }
   .back {
@@ -455,30 +477,34 @@ def _render_html(stats: dict, tasks: list[dict]) -> str:
 <div class="section">
   <h2>Live Stats</h2>
   <div class="stats">
-    <b>{stats["agents"]}</b> agents &middot;
-    <b>{stats["infra"]}</b> infra &middot;
-    <b>{stats["total_tasks"]}</b> tasks &middot;
-    <b>{stats["completed"]}</b> completed &middot;
-    <b>{stats["open"]}</b> open &middot;
-    <b>{stats["in_progress"]}</b> in progress &middot;
-    <b>{stats["credits_moved"]:,}</b> credits moved &middot;
-    <b>{stats["ratings"]}</b> ratings &middot;
-    <b>{stats["referrals"]}</b> referrals &middot;
-    <b>{stats["bonuses_paid"]}</b> bonuses paid
+    <span class="stat-item"><b>{stats["agents"]}</b> agents</span>
+    <span class="stat-item"><b>{stats["infra"]}</b> infra</span>
+    <span class="stat-item"><b>{stats["total_tasks"]}</b> tasks</span>
+    <span class="stat-item"><b>{stats["completed"]}</b> completed</span>
+    <span class="stat-item"><b>{stats["open"]}</b> open</span>
+    <span class="stat-item"><b>{stats["in_progress"]}</b> in progress</span>
+    <span class="stat-item"><b>{stats["credits_moved"]:,}</b> credits moved</span>
+    <span class="stat-item"><b>{stats["ratings"]}</b> ratings</span>
+    <span class="stat-item"><b>{stats["referrals"]}</b> referrals</span>
+    <span class="stat-item"><b>{stats["bonuses_paid"]}</b> bonuses paid</span>
   </div>
 </div>
 
 <div class="section">
   <h2>Recent Tasks</h2>
   <table>
-    <tr>
-      <th>ID</th>
-      <th>Need</th>
-      <th class="right">Credits</th>
-      <th>Status</th>
-      <th>When</th>
-    </tr>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Need</th>
+        <th class="right">Credits</th>
+        <th>Status</th>
+        <th>When</th>
+      </tr>
+    </thead>
+    <tbody>
     {task_rows}
+    </tbody>
   </table>
 </div>
 


### PR DESCRIPTION
The dashboard table breaks on mobile — task IDs are too wide, columns get cramped, and the layout doesn't adapt to narrow screens.

## Changes

- **Hide task ID column on mobile** (< 600px) — IDs are still accessible via the task link on the need text
- **Stack table rows as cards** using flex-wrap so each task reads naturally on narrow screens
- **Show credits/status/time inline** below the task need
- **Improve stats section** with better line spacing for readability
- **Shrink curl box font** so pickup commands don't overflow
- **Allow header to wrap** on very narrow screens

## Before
Table overflows, columns are squished, task IDs eat horizontal space.

## After
Each task shows as a compact card: need on top, credits ⚡ / status / time below.