### PR TITLE
fix: compact stats as 2-column grid on mobile

### DIFF
--- a/pinchwork/api/human.py
+++ b/pinchwork/api/human.py
@@ -181,10 +181,13 @@ _CSS = """\
     }
     .stats {
       font-size: 9pt;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0 12px;
     }
     .stat-item {
       display: block;
-      line-height: 1.8;
+      line-height: 1.6;
     }
     .stat-item::after {
       content: "";


### PR DESCRIPTION
Stats were stacking vertically taking up too much screen real estate on mobile. Now displays as a 2-column grid.