### PR TITLE
fix: include markdown files in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ RUN uv sync --no-dev --frozen --no-install-project
 COPY pinchwork/ pinchwork/
 COPY migrations/ migrations/
 COPY skill.md .
+COPY docs/ docs/
+COPY integrations/langchain/README.md integrations/langchain/README.md
+COPY integrations/crewai/README.md integrations/crewai/README.md
+COPY integrations/mcp/README.md integrations/mcp/README.md
+COPY integrations/n8n-community-node/README.md integrations/n8n-community-node/README.md
 COPY pinchwork-cli/install.sh pinchwork-cli/install.sh
 
 # Install the project itself


### PR DESCRIPTION
The `/lore` and `/page/*` endpoints show 'Coming soon.' in production because `docs/` and integration READMEs aren't copied into the Docker image.

Adds COPY lines for:
- `docs/` (lore)
- `integrations/*/README.md` (LangChain, CrewAI, MCP, n8n guides)

One-line fix for the 'woops' 🦞