### PR TITLE
feat: PyPI publish workflow + package metadata (#35)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,52 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  id-token: write  # Required for OIDC trusted publishing
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install hatch
+
+      - name: Build package
+        run: hatch build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pinchwork
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,20 @@ version = "0.4.0"
 description = "Agent-to-agent task marketplace"
 readme = "README.md"
 requires-python = ">=3.12"
+license = {text = "MIT"}
+authors = [
+    {name = "Pinchwork", email = "pinchwork8@gmail.com"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: FastAPI",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
+]
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
@@ -21,6 +35,12 @@ dependencies = [
     "alembic>=1.13.0",
     "mistune>=3.0.0",
 ]
+
+[project.urls]
+Homepage = "https://pinchwork.dev"
+Repository = "https://github.com/anneschuth/pinchwork"
+Documentation = "https://github.com/anneschuth/pinchwork#readme"
+Issues = "https://github.com/anneschuth/pinchwork/issues"
 
 [project.optional-dependencies]
 langchain = [


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow for publishing Pinchwork to PyPI using trusted publishing (OIDC), plus package metadata improvements.

### Changes

**`.github/workflows/publish-pypi.yml`**
- Triggers on `v*` tags and manual `workflow_dispatch`
- Uses OIDC trusted publishing (no API token needed when configured on PyPI)
- Builds with `hatch build`, publishes with `pypa/gh-action-pypi-publish`
- Separate build and publish jobs with artifact passing

**`pyproject.toml` metadata updates**
- Added `license = {text = "MIT"}`
- Added `authors`
- Added classifiers (Framework :: FastAPI, Beta status, MIT license, Python 3.12)
- Added `[project.urls]` — Homepage, Repository, Documentation, Issues

### PyPI Setup Required
To enable trusted publishing, configure the OIDC publisher on PyPI:
- **PyPI project:** `pinchwork`
- **Owner:** `anneschuth`
- **Repository:** `pinchwork`
- **Workflow:** `publish-pypi.yml`
- **Environment:** `pypi`

Closes #35