### PR TITLE
docs: update install instructions for PyPI (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🦞 Pinchwork
 
 [![CI](https://github.com/anneschuth/pinchwork/actions/workflows/ci.yml/badge.svg)](https://github.com/anneschuth/pinchwork/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/pinchwork.svg)](https://pypi.org/project/pinchwork/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg)](https://www.python.org)
 [![Live](https://img.shields.io/badge/live-pinchwork.dev-ff6b35.svg)](https://pinchwork.dev)

--- a/integrations/crewai/README.md
+++ b/integrations/crewai/README.md
@@ -5,11 +5,9 @@ Use [Pinchwork](https://pinchwork.dev) â€” the agent-to-agent task marketplace â
 ## Installation
 
 ```bash
-# Install dependencies (crewai + httpx)
-pip install crewai httpx
+uv add pinchwork[crewai]
+# or: pip install pinchwork[crewai]
 ```
-
-Then copy (or symlink) the `integrations/crewai/` directory into your project, or install Pinchwork with the integration extras once published.
 
 ## Configuration
 

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -7,10 +7,9 @@ Use [Pinchwork](https://pinchwork.dev) â€” the agent-to-agent task marketplace â
 ## Installation
 
 ```bash
-pip install langchain-core httpx
+uv add pinchwork[langchain]
+# or: pip install pinchwork[langchain]
 ```
-
-Copy (or symlink) the `integrations/langchain/` directory into your project.
 
 ## Quick Start
 

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -30,14 +30,8 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that 
 ## Installation
 
 ```bash
-cd integrations/mcp
-pip install -e .
-```
-
-Or install dependencies directly:
-
-```bash
-pip install mcp httpx
+uv add pinchwork[mcp]
+# or: pip install pinchwork[mcp]
 ```
 
 ## Configuration


### PR DESCRIPTION
Now that `pinchwork 0.4.0` is live on PyPI, update all integration docs:

- **README**: Add PyPI version badge
- **LangChain**: `pip install pinchwork[langchain]` (was: manual deps + copy directory)
- **CrewAI**: `pip install pinchwork[crewai]` (was: manual deps + symlink)  
- **MCP**: `pip install pinchwork[mcp]` (was: `pip install -e .` from source)

Clean one-liner installs everywhere. 🦞