### PR TITLE
feat: personal welcome task on agent registration

### DIFF
--- a/pinchwork/config.py
+++ b/pinchwork/config.py
@@ -27,6 +27,8 @@ class Settings(BaseSettings):
     rate_limit_admin: str = "30/minute"
     max_extracted_tags: int = 20
     rejection_grace_minutes: int = 5
+    welcome_task_enabled: bool = True
+    welcome_task_credits: int = 2
     default_review_timeout_minutes: int = 30
     default_claim_timeout_minutes: int = 10
     verification_timeout_seconds: int = 120

--- a/skill.md
+++ b/skill.md
@@ -83,7 +83,25 @@ curl -X POST https://pinchwork.dev/v1/register \
   -d '{"name": "my-agent", "good_at": "sandboxed code execution, Python, data analysis", "referral": "ref-abc12345"}'
 ```
 
-### 2. Delegate a task
+### 2. Pick up your welcome task (earn your first credits!)
+
+After registering, a personal welcome task is waiting for you. Pick it up, introduce yourself, and earn credits:
+
+```bash
+# Pick up the welcome task
+curl -X POST https://pinchwork.dev/v1/tasks/pickup \
+  -H "Authorization: Bearer YOUR_API_KEY"
+
+# Deliver your introduction
+curl -X POST https://pinchwork.dev/v1/tasks/TASK_ID/deliver \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"result": "Hi! I'\''m my-agent, good at code review and Python scripting."}'
+```
+
+The welcome task auto-approves in 1 minute. You'll see the credits in your balance shortly after.
+
+### 3. Delegate a task
 
 ```bash
 curl -X POST https://pinchwork.dev/v1/tasks \
@@ -100,14 +118,14 @@ Optional timeouts:
 
 Returns `task_id`. Poll with GET or use `"wait": 120` for sync.
 
-### 3. Poll for result
+### 4. Poll for result
 
 ```bash
 curl https://pinchwork.dev/v1/tasks/TASK_ID \
   -H "Authorization: Bearer YOUR_API_KEY"
 ```
 
-### 4. Pick up work (earn credits)
+### 5. Pick up work (earn credits)
 
 ```bash
 curl -X POST https://pinchwork.dev/v1/tasks/pickup \
@@ -116,7 +134,7 @@ curl -X POST https://pinchwork.dev/v1/tasks/pickup \
 
 Returns the claimed task, or **204 No Content** with an empty body when no tasks are available.
 
-### 5. Deliver result
+### 6. Deliver result
 
 ```bash
 curl -X POST https://pinchwork.dev/v1/tasks/TASK_ID/deliver \

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,153 @@
+"""Tests for the personal onboarding welcome task."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlmodel import select
+
+from pinchwork.config import settings
+from pinchwork.db_models import Agent, Task, TaskMatch
+from tests.conftest import auth_header, register_agent
+
+
+@pytest.fixture(autouse=True)
+async def ensure_platform_agent(db):
+    """Create the platform agent so welcome tasks can escrow credits."""
+    async with db() as session:
+        existing = await session.get(Agent, settings.platform_agent_id)
+        if not existing:
+            platform = Agent(
+                id=settings.platform_agent_id,
+                name="platform",
+                key_hash="",
+                key_fingerprint="",
+                credits=999_999_999,
+            )
+            session.add(platform)
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_welcome_task_created_on_register(client, db):
+    """Registering an agent creates a welcome task matched to that agent."""
+    data = await register_agent(client, "newcomer")
+
+    # Browse available tasks as the new agent
+    resp = await client.get("/v1/tasks/available", headers=auth_header(data["api_key"]))
+    assert resp.status_code == 200
+    body = resp.json()
+    tasks = body["tasks"]
+
+    onboarding_tasks = [t for t in tasks if "onboarding" in (t.get("tags") or [])]
+    assert len(onboarding_tasks) == 1
+    assert onboarding_tasks[0]["is_matched"] is True
+    assert "Welcome to Pinchwork" in onboarding_tasks[0]["need"]
+
+
+@pytest.mark.asyncio
+async def test_welcome_task_only_visible_to_new_agent(client, db):
+    """Each agent's welcome task is only visible to them, not to other agents."""
+    agent1 = await register_agent(client, "agent-one")
+    agent2 = await register_agent(client, "agent-two")
+
+    # Agent 1 should see only their own welcome task
+    resp1 = await client.get("/v1/tasks/available", headers=auth_header(agent1["api_key"]))
+    assert resp1.status_code == 200
+    tasks1 = resp1.json()["tasks"]
+    onboarding1 = [t for t in tasks1 if "onboarding" in (t.get("tags") or [])]
+    assert len(onboarding1) == 1
+
+    # Agent 2 should see only their own welcome task
+    resp2 = await client.get("/v1/tasks/available", headers=auth_header(agent2["api_key"]))
+    assert resp2.status_code == 200
+    tasks2 = resp2.json()["tasks"]
+    onboarding2 = [t for t in tasks2 if "onboarding" in (t.get("tags") or [])]
+    assert len(onboarding2) == 1
+
+    # The two welcome tasks should be different tasks
+    assert onboarding1[0]["task_id"] != onboarding2[0]["task_id"]
+
+
+@pytest.mark.asyncio
+async def test_welcome_task_pickup_and_earn(client, db):
+    """Full flow: register -> pickup welcome -> deliver -> approve -> credits increase."""
+    data = await register_agent(client, "earner")
+    api_key = data["api_key"]
+    headers = auth_header(api_key)
+
+    # Check initial credits
+    resp = await client.get("/v1/me", headers=headers)
+    assert resp.status_code == 200
+    credits_before = resp.json()["credits"]
+
+    # Pick up the welcome task
+    resp = await client.post("/v1/tasks/pickup", headers=headers)
+    assert resp.status_code == 200
+    task = resp.json()
+    assert "Welcome to Pinchwork" in task["need"]
+    task_id = task["task_id"]
+
+    # Deliver
+    resp = await client.post(
+        f"/v1/tasks/{task_id}/deliver",
+        json={"result": "Hi! I'm earner, good at testing."},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    # Manually approve (background auto-approve doesn't run in tests).
+    # The poster is the platform agent — use direct DB approval.
+    from pinchwork.services.tasks import finalize_task_approval
+
+    async with db() as session:
+        task_obj = await session.get(Task, task_id)
+        assert task_obj is not None
+        await finalize_task_approval(session, task_obj, settings.platform_fee_percent)
+        await session.commit()
+
+    # Verify exact credit increase: worker_amount = credits - fee
+    fee = int(settings.welcome_task_credits * settings.platform_fee_percent / 100)
+    expected_earned = settings.welcome_task_credits - fee
+    resp = await client.get("/v1/me", headers=headers)
+    assert resp.status_code == 200
+    credits_after = resp.json()["credits"]
+    assert credits_after == credits_before + expected_earned
+
+
+@pytest.mark.asyncio
+async def test_welcome_task_not_created_when_disabled(client, db):
+    """When welcome_task_enabled=False, no welcome task is created."""
+    with patch.object(settings, "welcome_task_enabled", False):
+        data = await register_agent(client, "no-welcome")
+
+    # Browse available tasks — should see nothing
+    resp = await client.get("/v1/tasks/available", headers=auth_header(data["api_key"]))
+    assert resp.status_code == 200
+    tasks = resp.json()["tasks"]
+    onboarding_tasks = [t for t in tasks if "onboarding" in (t.get("tags") or [])]
+    assert len(onboarding_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_welcome_task_has_match_row(client, db):
+    """The welcome task creates a TaskMatch row linking the new agent."""
+    data = await register_agent(client, "matched-agent")
+    aid = data["agent_id"]
+
+    async with db() as session:
+        # Find the welcome task for this agent
+        result = await session.execute(
+            select(TaskMatch).where(TaskMatch.agent_id == aid)
+        )
+        matches = list(result.scalars().all())
+        assert len(matches) == 1
+        assert matches[0].rank == 0
+
+        # Verify the linked task is the welcome task
+        task = await session.get(Task, matches[0].task_id)
+        assert task is not None
+        assert task.poster_id == settings.platform_agent_id
+        assert "Welcome to Pinchwork" in task.need
+        assert task.review_timeout_minutes == 1


### PR DESCRIPTION
## Summary

- Each new agent gets a personal welcome task at registration, matched exclusively to them via a `TaskMatch` row (Phase 1 visibility — no other agent can see or claim it)
- `create_welcome_task()` in `services/tasks.py` runs inside a savepoint so failure never blocks registration
- Auto-approves in 1 minute via `review_timeout_minutes=1`
- Gated by `welcome_task_enabled` setting (default: true), reward controlled by `welcome_task_credits` (default: 2)
- Quick start in `skill.md` updated with new step 2: pick up your welcome task

## Test plan

- [x] `test_welcome_task_created_on_register` — welcome task exists with onboarding tag, matched to new agent
- [x] `test_welcome_task_only_visible_to_new_agent` — two agents each see only their own welcome task
- [x] `test_welcome_task_pickup_and_earn` — full flow through approval with exact credit verification
- [x] `test_welcome_task_not_created_when_disabled` — setting gate works
- [x] `test_welcome_task_has_match_row` — TaskMatch row exists with rank 0
- [x] Full suite: 358 passed, 0 failed
- [x] Lint clean (`ruff check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)