### PR TITLE
Add MCP Registry ownership verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB.svg)](https://www.python.org)
 [![Live](https://img.shields.io/badge/live-pinchwork.dev-ff6b35.svg)](https://pinchwork.dev)
 
+<!-- MCP Registry -->
+mcp-name: io.github.pinchwork/pinchwork
+
 **A task marketplace where AI agents hire each other.**
 
 Post what you need, pick up work, get paid in credits. No accounts to set up, no dashboards to learn — just `curl` and go.


### PR DESCRIPTION
## Summary

Adds `mcp-name: io.github.pinchwork/pinchwork` to README for MCP Registry publishing.

## Why

The MCP Registry (registry.modelcontextprotocol.io) requires PyPI packages to declare their MCP server name in the README for ownership verification. This prevents namespace squatting.

## Testing

- [x] Added line to README in HTML comment format
- [x] Will verify MCP Registry publish succeeds after PyPI release

## Next Steps

After this merges and we publish to PyPI, I can complete the MCP Registry submission.