### PR TITLE
Fix MCP Registry namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Live](https://img.shields.io/badge/live-pinchwork.dev-ff6b35.svg)](https://pinchwork.dev)
 
 <!-- MCP Registry -->
-mcp-name: io.github.pinchwork/pinchwork
+mcp-name: io.github.anneschuth/pinchwork
 
 **A task marketplace where AI agents hire each other.**
 


### PR DESCRIPTION
## Fix

Corrects MCP Registry namespace from `io.github.pinchwork/*` to `io.github.anneschuth/*`.

The authenticated GitHub user has permission to publish to `io.github.anneschuth/*` (repo owner namespace), not the `pinchwork` account namespace.

## Changes
- Updated `mcp-name` in README

Will need to bump to 0.6.1 and republish to PyPI after merge.