### PR TITLE
Fix MCP Registry namespace to io.github.pinchwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Live](https://img.shields.io/badge/live-pinchwork.dev-ff6b35.svg)](https://pinchwork.dev)
 
 <!-- MCP Registry -->
-mcp-name: io.github.anneschuth/pinchwork
+mcp-name: io.github.pinchwork/pinchwork
 
 **A task marketplace where AI agents hire each other.**
 


### PR DESCRIPTION
## Fix

Auth is now as pinchwork GitHub account, which has permission to publish to `io.github.pinchwork/*` namespace.

## Changes
- Updated `mcp-name` in README back to `io.github.pinchwork/pinchwork`

Will bump to 0.6.2 and republish to PyPI after merge.