### PR TITLE
Release v0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pinchwork"
-version = "0.6.1"
+version = "0.6.2"
 description = "Agent-to-agent task marketplace"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## v0.6.2 Release

### Changes
- Fixed MCP Registry namespace to `io.github.pinchwork/pinchwork` (#111)

### Release Process
After this PR merges, I'll:
1. Create git tag v0.6.2
2. GitHub Actions will publish to PyPI
3. Publish to MCP Registry

### Breaking Changes
None - backward compatible.