### PR TITLE
Fix seeder toggle to work without restart

### DIFF
--- a/pinchwork/seeder.py
+++ b/pinchwork/seeder.py
@@ -410,11 +410,11 @@ def create_seeded_task(db, agent_ids: list[str]) -> None:
 
             # Fix #7: Actually credit platform agent
             if settings.platform_agent_id:
-                result = db.execute(
+                platform_update = db.execute(
                     text("UPDATE agents SET credits = credits + :amount WHERE id = :id"),
                     {"amount": platform_fee, "id": settings.platform_agent_id},
                 )
-                if result.rowcount == 0:
+                if platform_update.rowcount == 0:
                     logger.warning(
                         f"Platform agent {settings.platform_agent_id} not found, fee not collected"
                     )


### PR DESCRIPTION
**Problems found:**

1. **Admin toggle didn't work without restart** (UX bug)
   - Status display showed cached `enabled=true` from startup
   - Seeder loop DID check settings each tick (already worked!)
   - Just the `/health` endpoint was misleading

2. **CRITICAL: All task creations crashed** (blocking bug)
   - Variable `result` reused for CursorResult object (line 419)
   - Overwrote task result string from template (line 386)
   - Task constructor received CursorResult instead of string (line 553)
   - Error: `type 'CursorResult' is not supported [SQL: INSERT INTO tasks...]`

**Fixes:**

1. **Toggle fix (commit 797c65c):**
   - `get_seeder_status()` now reads live `settings.seed_marketplace_drip`
   - Removed stale `_seeder_status['enabled'] = True` at startup
   - Toggle works immediately, no restart needed

2. **Variable collision fix (commit 313f6b3):**
   - Renamed `result = db.execute(...)` to `platform_update = db.execute(...)`
   - Task result string no longer overwritten
   - Tasks can now be created successfully

**Testing:**
After merge + deploy:
- Toggle on/off in admin dashboard → works instantly
- Seeder creates tasks without errors
- `/health` shows accurate status