### PR TITLE
Fix seeder timezone alignment for European hours

### DIFF
--- a/pinchwork/seeder.py
+++ b/pinchwork/seeder.py
@@ -612,14 +612,14 @@ async def drip_seeder_loop():
                 # Ensure agent pool exists (fix #11: idempotency)
                 agent_ids = ensure_seeded_agents(db)
 
-                # Calculate tasks to create based on time of day
+                # Calculate tasks to create based on time of day (CET aligned)
                 hour = datetime.utcnow().hour
 
-                if 9 <= hour < 18:
+                if 7 <= hour < 21:  # 8-22 CET (extended business day)
                     lambda_rate = settings.seed_drip_rate_business
-                elif 18 <= hour < 23:
+                elif 21 <= hour < 23:  # 22-24 CET (short evening)
                     lambda_rate = settings.seed_drip_rate_evening
-                else:
+                else:  # 0-8 CET (night)
                     lambda_rate = settings.seed_drip_rate_night
 
                 # Poisson sample for 10-minute interval (capped at 10 to prevent outliers)


### PR DESCRIPTION
**Problem 1: Wrong timezone**
Seeder used UTC hours for time-based rates, causing night mode during European daytime.
- At 08:41 UTC = 09:41 CET (Netherlands business hours)
- Seeder saw hour=8 → night rate (0.5/hour) → almost no tasks

**Problem 2: Business hours too short**
Original 9-18 UTC = only 9 hours of business activity

**Fix:**
Aligned to CET (UTC+1) and extended business day:
- **Business:** 7-21 UTC → **8-22 CET (14 hours!)** - was 9-18 UTC (9h)
- **Evening:** 21-23 UTC → 22-24 CET (2 hours) - was 18-23 UTC (5h)
- **Night:** 23-7 UTC → 0-8 CET (8 hours) - was 23-9 UTC (10h)

**Impact:**
- Business rate (8 tasks/hour) active for full European working day + evening
- Current time (09:41 CET) = business mode ✅
- Tasks will start appearing at 8/hour rate after deploy

**Rates:**
- Business: 8 tasks/hour (14 hours/day)
- Evening: 3 tasks/hour (2 hours/day)  
- Night: 0.5 tasks/hour (8 hours/day)