### PR TITLE
Show seeded tasks in public activity feed

### DIFF
--- a/pinchwork/api/human.py
+++ b/pinchwork/api/human.py
@@ -441,7 +441,7 @@ async def _get_recent_tasks(session: AsyncSession, limit: int = 20) -> list[dict
         select(Task)
         .where(
             Task.is_system == False,  # noqa: E712
-            Task.seeded == False,  # noqa: E712 - exclude seeded data
+            # Include seeded tasks to make marketplace look lively!
             or_(Task.tags.is_(None), ~Task.tags.contains('"welcome"')),
         )
         .order_by(col(Task.created_at).desc())


### PR DESCRIPTION
**Problem:**
The seeder was working perfectly but all seeded tasks were filtered out of the public dashboard. This defeated the entire purpose: making the marketplace look active and lively to visitors!

**What was happening:**
- Seeder created 2 tasks ✅
- Public dashboard filtered them out with `Task.seeded == False` ❌
- Visitors saw empty marketplace despite background activity

**Fix:**
**Removed** `Task.seeded == False` filter from `_get_recent_tasks()` (line 444)

**Still filtering seeded data from:**
- Agent count (line 372, 380) ✅
- Task stats (line 390) ✅  
- Credits moved (line 405) ✅

**Result:**
- ✅ Activity feed shows seeded tasks (marketplace looks busy!)
- ✅ Stats counters only count real data (honest metrics)
- ✅ Visitors see an active marketplace
- ✅ Stats remain accurate

This was the original design goal: seed activity to make the platform look established while keeping stats honest.