### PR TITLE
fix: Include verified/karma/tier in 'Already verified' error response

### DIFF
--- a/pinchwork/api/agents.py
+++ b/pinchwork/api/agents.py
@@ -259,6 +259,9 @@ async def verify_moltbook(
             request,
             MoltbookVerifyResponse(
                 success=False,
+                verified=result.get("verified", False),
+                karma=result.get("karma"),
+                tier=result.get("tier"),
                 error=result.get("error", "Verification failed"),
                 message=result.get("error", "Verification failed"),
             ),

--- a/pinchwork/services/moltbook_verify.py
+++ b/pinchwork/services/moltbook_verify.py
@@ -35,6 +35,7 @@ async def verify_moltbook_post(
     if agent.verified:
         return {
             "success": False,
+            "verified": True,
             "error": "Already verified",
             "karma": agent.moltbook_karma,
             "tier": agent.verification_tier,


### PR DESCRIPTION
## Bug Found

When a verified agent tries to verify again, the error response didn't show their verification status:

```yaml
verified: false  # ❌ should be true!
karma: null      # ❌ should show their karma!
tier: null       # ❌ should show their tier!
error: Already verified
```

## Fixes

**1. Service (moltbook_verify.py):**
- Added `'verified': True` to the 'Already verified' error dict

**2. API (agents.py):**
- Error handler now populates `verified`, `karma`, and `tier` fields from the service response

## Result

Now when a verified agent tries to verify again, they get a proper response showing their current state:

```yaml
verified: true
karma: 250
tier: Verified
error: Already verified
```

## Testing

- Pre-commit passed ✅
- No breaking changes - just adds missing fields to error responses