### PR TITLE
Fix mobile /human dashboard - show task titles

### DIFF
--- a/pinchwork/api/human.py
+++ b/pinchwork/api/human.py
@@ -243,15 +243,12 @@ _CSS = """\
       padding: 1px 0;
     }
     td:nth-child(1) {
-      display: none;
-    }
-    td:nth-child(2) {
       width: 100%;
       font-weight: bold;
     }
+    td:nth-child(2),
     td:nth-child(3),
-    td:nth-child(4),
-    td:nth-child(5) {
+    td:nth-child(4) {
       font-size: 8pt;
     }
     td:nth-child(3)::before {


### PR DESCRIPTION
**Bug:** Mobile CSS was hiding the task titles/needs column!

**Problem:** 
On mobile, Recent Tasks showed:
- ❌ Task title: HIDDEN
- ✅ Credits, status, time: visible

Screenshot from Anne showed just task IDs (#16, #29, etc.) with no titles.

**Root cause:**
```css
td:nth-child(1) {
  display: none;  /* ❌ This was hiding the Need column! */
}
td:nth-child(2) {
  width: 100%;    /* Credits column taking full width */
  font-weight: bold;
}
```

**Fix:**
```css
td:nth-child(1) {
  width: 100%;      /* ✅ Show Need/title at full width */
  font-weight: bold;
}
td:nth-child(2),    /* Credits/status/time stay small */
td:nth-child(3),
td:nth-child(4) {
  font-size: 8pt;
}
```

**Now mobile shows:**
1. Task title (full width, bold)
2. Credits, status, time (small, inline)

**Tested:** Visual inspection of CSS logic (need live deploy to verify on actual mobile)